### PR TITLE
Add CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         working_directory: ~/media-consent
         steps:
             - checkout
-            - run: "make"
+            - run: make COMPILESVG=svg2pdf
             - store_artifacts:
                 path: form.pdf
                 destination: form.pdf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+    build:
+        docker:
+            - image: theorangeone/docker-pandoc
+        working_directory: ~/media-consent
+        steps:
+            - checkout
+            - run: "make"
+            - store_artifacts:
+                path: form.pdf
+                destination: form.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-COMPILESVG=svg2pdf
+HAS_INKSCAPE := $(shell inkscape --version 2>/dev/null)
+HAS_SVG2PDF := $(shell svg2pdf --version 2>/dev/null)
 
 PDFLATEXFLAGS=-halt-on-error -interaction nonstopmode
 
@@ -12,13 +13,13 @@ form.pdf: form.tex fig-SourceBots.pdf
 	pdflatex $(PDFLATEXFLAGS) $<
 
 fig-%.pdf: fig-%.svg
-ifeq ($(COMPILESVG),inkscape)
+ifdef HAS_INKSCAPE
 	inkscape -A `pwd`/$@ `pwd`/$<
 else
-ifeq ($(COMPILESVG),svg2pdf)
+ifdef HAS_SVG2PDF
 	svg2pdf $< $@
 else
-	echo "Unknown COMPILESVG."; false
+	echo "No supported SVG build tools available"; false
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-HAS_INKSCAPE := $(shell inkscape --version 2>/dev/null)
-HAS_SVG2PDF := $(shell svg2pdf --version 2>/dev/null)
+COMPILESVG=svg2pdf
 
 PDFLATEXFLAGS=-halt-on-error -interaction nonstopmode
 
@@ -13,13 +12,13 @@ form.pdf: form.tex fig-SourceBots.pdf
 	pdflatex $(PDFLATEXFLAGS) $<
 
 fig-%.pdf: fig-%.svg
-ifdef HAS_INKSCAPE
+ifeq ($(COMPILESVG),inkscape)
 	inkscape -A `pwd`/$@ `pwd`/$<
 else
-ifdef HAS_SVG2PDF
+ifeq ($(COMPILESVG),svg2pdf)
 	svg2pdf $< $@
 else
-	echo "No supported SVG build tools available"; false
+	echo "Unknown COMPILESVG."; false
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+COMPILESVG=svg2pdf
+
 PDFLATEXFLAGS=-halt-on-error -interaction nonstopmode
 
 all: form.pdf
@@ -10,7 +12,15 @@ form.pdf: form.tex fig-SourceBots.pdf
 	pdflatex $(PDFLATEXFLAGS) $<
 
 fig-%.pdf: fig-%.svg
+ifeq ($(COMPILESVG),inkscape)
+	inkscape -A `pwd`/$@ `pwd`/$<
+else
+ifeq ($(COMPILESVG),svg2pdf)
 	svg2pdf $< $@
+else
+	echo "Unknown COMPILESVG."; false
+endif
+endif
 
 watch:
 	make

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPILESVG=svg2pdf
+COMPILESVG=inkscape
 
 PDFLATEXFLAGS=-halt-on-error -interaction nonstopmode
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPILESVG=inkscape
+COMPILESVG=svg2pdf
 
 PDFLATEXFLAGS=-halt-on-error -interaction nonstopmode
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-COMPILESVG=svg2pdf
-
 PDFLATEXFLAGS=-halt-on-error -interaction nonstopmode
 
 all: form.pdf
@@ -12,15 +10,7 @@ form.pdf: form.tex fig-SourceBots.pdf
 	pdflatex $(PDFLATEXFLAGS) $<
 
 fig-%.pdf: fig-%.svg
-ifeq ($(COMPILESVG),inkscape)
-	inkscape -A `pwd`/$@ `pwd`/$<
-else
-ifeq ($(COMPILESVG),svg2pdf)
 	svg2pdf $< $@
-else
-	echo "Unknown COMPILESVG."; false
-endif
-endif
 
 watch:
 	make

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Media Consent Form
 
+[![CircleCI](https://circleci.com/gh/sourcebots/media-consent.svg?style=svg)](https://circleci.com/gh/sourcebots/media-consent)
+
 This is the form for students to grant media consent for our events, so we can take pictures and record video at will.
 
 


### PR DESCRIPTION
Use CircleCI to build the the PDF and store as artifact. 

Uses https://github.com/RealOrangeOne/docker-pandoc

Have removed `inkscape` as a build tool, as `svg2pdf` is far smaller and lighter-weight. Am happy to restore conditional if necessary.