### PR TITLE
Add MCF validation instructions

### DIFF
--- a/validation.md
+++ b/validation.md
@@ -1,0 +1,9 @@
+# Validating a media consent
+
+- Check the event name in the top right, and the 1st sentence, both match the event the person is trying to attend.
+
+- Make sure the full name and address fields are filled in, and the values are sane-looking.
+
+- 1 and only 1 of the signature section boxes have been filled.
+
+- The date should be some point before the date of the event, and after the forms were sent out. The send date may not be known, if so, use your own disgression on a valid date.


### PR DESCRIPTION
Validation steps for an MCF are important, to make sure we don't accidentally accept what we later find out to be a void form.